### PR TITLE
Prometheus Couch Exporter Updates

### DIFF
--- a/charts/prometheus-couchdb-exporter/Chart.yaml
+++ b/charts/prometheus-couchdb-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "22"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://gkarthiks.github.io/helm-charts/charts/couchdb-prometheus-exporter
-version: 0.1.0
+version: 0.1.2
 keywords:
 - couchdb-exporter
 - prometheus

--- a/charts/prometheus-couchdb-exporter/Chart.yaml
+++ b/charts/prometheus-couchdb-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "22"
+appVersion: "v27.2.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://gkarthiks.github.io/helm-charts/charts/couchdb-prometheus-exporter

--- a/charts/prometheus-couchdb-exporter/README.md
+++ b/charts/prometheus-couchdb-exporter/README.md
@@ -60,6 +60,9 @@ The following table lists the configurable parameters and their default values.
 | `podAnnotations`	     | annotations to add to each pod					   | {}                                      |
 | `couchdb.uri`          | address of the couchdb                              | `http://couchdb.default.svc:5984`       |
 | `couchdb.databases`    | comma separated databases to monitor                | `_all_dbs`                              |
+| `couchdb.username`     | username for couchdb                                |                                         |
+| `couchdb.password`     | password for couchdb                                |                                         |
+| `secretName`           | secret to pull adminUsername and adminPassword      |                                         |
 
 
 For more information please refer to the [couchdb-prometheus-exporter]https://github.com/gesellix/couchdb-prometheus-exporter) documentation.

--- a/charts/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -38,12 +38,12 @@ spec:
             httpGet:
               path: /status
               port: http
-              initialDelaySeconds: 60
+            initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: /status
               port: http
-              initialDelaySeconds: 60
+            initialDelaySeconds: 60
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/charts/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -30,7 +30,27 @@ spec:
                     "-telemetry.address=0.0.0.0:9984",
                     "-logtostderr",
                     "-couchdb.uri={{ .Values.couchdb.uri }}",
+{{- if .Values.couchdb.username }}
+                    "-couchdb.username={{ .Values.couchdb.username }}",
+{{- end }}
+{{- if .Values.couchdb.password }}
+                    "-couchdb.password={{ .Values.couchdb.password }}",
+{{- end }}
                     "-databases={{ .Values.couchdb.databases }}"]
+
+{{- if .Values.secretName }}
+          env:
+            - name: COUCHDB.USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: adminUsername
+            - name: COUCHDB.PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: adminPassword
+{{- end }}
           ports:
             - name: http
               containerPort: 9984

--- a/charts/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -63,7 +63,10 @@ spec:
             httpGet:
               path: /status
               port: http
-            initialDelaySeconds: 60
+            failureThreshold: 3
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/charts/prometheus-couchdb-exporter/templates/ingress.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "prometheus-couchdb-exporter.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-couchdb-exporter.fullname" . }}

--- a/charts/prometheus-couchdb-exporter/templates/service.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "prometheus-couchdb-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/port: "9984"
+    prometheus.io/scrape: "true"
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/prometheus-couchdb-exporter/values.yaml
+++ b/charts/prometheus-couchdb-exporter/values.yaml
@@ -18,7 +18,7 @@ replicaCount: 1
 
 image:
   repository: gesellix/couchdb-prometheus-exporter
-  tag: 22
+  tag: v27.2.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
- Updated some removed `apiVersion`
- Added prometheus scrape annotations to work with [annotations](https://github.com/helm/charts/tree/master/stable/prometheus#scraping-pod-metrics-via-annotations)
- Added user/password via values or via secrets
- Updated the underlying image to v27.2