### PR TITLE
Update PSP apiVersion and add serviceMonitor

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.2.0"
 description: Prometheus metrics exporter for Kafka
 name: prometheus-kafka-exporter
-version: 0.1.0
+version: 0.1.1
 home: https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 sources:
   - https://github.com/danielqsj/kafka_exporter

--- a/charts/prometheus-kafka-exporter/README.md
+++ b/charts/prometheus-kafka-exporter/README.md
@@ -42,22 +42,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters and their default values.
 
-| Parameter              | Description                                         | Default                   |
-| ---------------------- | --------------------------------------------------- | ------------------------- |
-| `replicaCount`         | desired number of prometheus-kafka-exporter pods    | `1`                       |
-| `image.repository`     | prometheus-kafka-exporter image repository          | `danielqsj/kafka-exporter`|
-| `image.tag`            | prometheus-kafka-exporter image tag                 | `latest`                  |
-| `image.pullPolicy`     | image pull policy                                   | `IfNotPresent`            |
-| `resources`            | cpu/memory resource requests/limits                 | {}                        |
-| `service.type`         | desired service type                                | `ClusterIP`               |
-| `service.port`         | service external port                               | `9308`                    |
-| `service.annotations`  | annotations for service                             | {}                        |
-| `kafkaServer`          | Kafka server addresses as an array with port number |                           |
-| `annotations`          | pod annotations for easier discovery                | {}                        |
-| `rbac.create`           | Specifies whether RBAC resources should be created.| `true`                    |
-| `rbac.pspEnabled`       | Specifies whether a PodSecurityPolicy should be created.| `true`               |
-| `serviceAccount.create` | Specifies whether a service account should be created.| `true`                 |
-| `serviceAccount.name`   | Name of the service account.|                                                  |
+| Parameter                                        | Description                                              | Default                     |
+| ------------------------------------------------ | -------------------------------------------------------- | --------------------------- |
+| `replicaCount`                                   | desired number of prometheus-kafka-exporter pods         | `1`                         |
+| `image.repository`                               | prometheus-kafka-exporter image repository               | `danielqsj/kafka-exporter`  |
+| `image.tag`                                      | prometheus-kafka-exporter image tag                      | `latest`                    |
+| `image.pullPolicy`                               | image pull policy                                        | `IfNotPresent`              |
+| `resources`                                      | cpu/memory resource requests/limits                      | {}                          |
+| `service.type`                                   | desired service type                                     | `ClusterIP`                 |
+| `service.port`                                   | service external port                                    | `9308`                      |
+| `service.annotations`                            | annotations for service                                  | {}                          |
+| `kafkaServer`                                    | Kafka server addresses as an array with port number      |                             |
+| `annotations`                                    | pod annotations for easier discovery                     | {}                          |
+| `rbac.create`                                    | Specifies whether RBAC resources should be created.      | `true`                      |
+| `rbac.pspEnabled`                                | Specifies whether a PodSecurityPolicy should be created. | `true`                      |
+| `serviceAccount.create`                          | Specifies whether a service account should be created.   | `true`                      |
+| `serviceAccount.name`                            | Name of the service account.                             | ``                          |
+| `prometheus.serviceMonitor.enabled.`             | Whether you would like to enable a serviceMonitor        | `true`                      |
+| `prometheus.serviceMonitor.namespace.`           | The namespace to create the serviceMonitor in            | `monitoring`                |
+| `prometheus.serviceMonitor.interval`             | Interval at which metrics should be scraped              | `prometheus-kafka-exporter` |
+| `prometheus.serviceMonitor.additionalLabels.app` | Additional labels to add to the ServiceMonitor           | `{}`                       |
 
 For more information please refer to the [kafka_exporter](https://github.com/danielqsj/kafka_exporter) documentation.
 

--- a/charts/prometheus-kafka-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-kafka-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-kafka-exporter.fullname" . }}

--- a/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
+++ b/charts/prometheus-kafka-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prometheus-kafka-exporter.fullname" . }}
+  {{- if .Values.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-kafka-exporter.name" . }}
+    helm.sh/chart: {{ include "prometheus-kafka-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.prometheus.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.prometheus.serviceMonitor.additionalLabels | indent 4 -}}
+    {{- end }}
+spec:
+  jobLabel: jobLabel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-kafka-exporter.name" . }}
+      helm.sh/chart: {{ include "prometheus-kafka-exporter.chart" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: exporter-port
+    interval: {{ .Values.prometheus.serviceMonitor.interval }}
+    {{- if .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+{{- end }}

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -29,8 +29,7 @@ prometheus:
     enabled: true
     namespace: monitoring
     interval: "30s"
-    additionalLabels:
-      app: prometheus-kafka-exporter
+    additionalLabels: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/prometheus-kafka-exporter/values.yaml
+++ b/charts/prometheus-kafka-exporter/values.yaml
@@ -24,6 +24,14 @@ service:
   port: 9308
   annotations: {}
 
+prometheus:
+  serviceMonitor:
+    enabled: true
+    namespace: monitoring
+    interval: "30s"
+    additionalLabels:
+      app: prometheus-kafka-exporter
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
* Updates the `PodSecurityPolicy` to use the latest `apiVersion`. Installing the current chart on a k8s 1.16+ cluster fails since it's been deprecated.
* Adds a `serviceMonitor` to easily export Prometheus metrics