### PR TITLE
add multi-namespace support and support for using an existing role

### DIFF
--- a/charts/prometheus-container-resource-exporter/Chart.yaml
+++ b/charts/prometheus-container-resource-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.1.1"
-description: Prometheus metrics exporter for conatiner resources
+appVersion: "0.2.1"
+description: Prometheus metrics exporter for container resources
 name: prometheus-container-resource-exporter
-version: 0.1.0
+version: 0.2.0
 home: https://gkarthiks.github.io/container-resource-exporter/
 sources:
   - https://github.com/gkarthiks/container-resource-exporter

--- a/charts/prometheus-container-resource-exporter/templates/cluster-role.yaml
+++ b/charts/prometheus-container-resource-exporter/templates/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.runScope.cluster -}}
+{{- if and .Values.runScope.cluster (not .Values.useExistingRole) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/prometheus-container-resource-exporter/templates/cluster-rolebinding.yaml
+++ b/charts/prometheus-container-resource-exporter/templates/cluster-rolebinding.yaml
@@ -11,7 +11,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+{{- if (not .Values.useExistingRole) }}
   name: {{ template "prometheus-container-resource-exporter.fullname" . }}
+{{- else }}
+  name: {{ .Values.useExistingRole }}
+{{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "prometheus-container-resource-exporter.serviceAccountName" . }}

--- a/charts/prometheus-container-resource-exporter/templates/deployment.yaml
+++ b/charts/prometheus-container-resource-exporter/templates/deployment.yaml
@@ -27,13 +27,18 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.runScope.local }}
+{{- if and .Values.runScope.local (not .Values.runScope.namespaces)  }}
           env:
           - name: WATCH_NAMESPACE
             valueFrom:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
+{{- end }}
+{{- if and .Values.runScope.local .Values.runScope.namespaces  }}
+          env:
+          - name: WATCH_NAMESPACE
+            value: {{ join "," .Values.runScope.namespaces }}
 {{- end }}
           ports:
             - containerPort: 9000

--- a/charts/prometheus-container-resource-exporter/templates/local-role.yaml
+++ b/charts/prometheus-container-resource-exporter/templates/local-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.runScope.local -}}
+{{- if and .Values.runScope.local (not .Values.useExistingRole) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/prometheus-container-resource-exporter/templates/local-rolebinding.yaml
+++ b/charts/prometheus-container-resource-exporter/templates/local-rolebinding.yaml
@@ -1,20 +1,52 @@
 {{- if .Values.runScope.local -}}
+{{- if empty .Values.runScope.namespaces -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app: {{ template "prometheus-container-resource-exporter.name" . }}
-    chart: {{ template "prometheus-container-resource-exporter.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ template "prometheus-container-resource-exporter.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+    app: {{ template "prometheus-container-resource-exporter.name" $ }}
+    chart: {{ template "prometheus-container-resource-exporter.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+  name: {{ template "prometheus-container-resource-exporter.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
+{{- if (not .Values.useExistingRole) }}
   name: {{ template "prometheus-container-resource-exporter.fullname" . }}
+{{- else }}
+  name: {{ .Values.useExistingRole }}
+{{- end }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "prometheus-container-resource-exporter.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "prometheus-container-resource-exporter.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- else }}
+{{- range $.Values.runScope.namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "prometheus-container-resource-exporter.name" $ }}
+    chart: {{ template "prometheus-container-resource-exporter.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+  name: {{ template "prometheus-container-resource-exporter.fullname" $ }}
+  namespace: {{ . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{{- if (not $.Values.useExistingRole) }}
+  name: {{ template "prometheus-container-resource-exporter.fullname" $ }}
+{{- else }}
+  name: {{ $.Values.useExistingRole }}
+{{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-container-resource-exporter.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- end -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
This adds support for using an existing role (f.ex. in Openshift environments one often does not have privileges to create any role's - but can create the rolebindings).
It also adds support for specifying multiple namespaces, to monitor.