### PR TITLE
fix: [Prometheus-Kafka-Exporter] fix tls.enabled

### DIFF
--- a/charts/prometheus-kafka-exporter/Chart.yaml
+++ b/charts/prometheus-kafka-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.2.0"
 description: Prometheus metrics exporter for Kafka
 name: prometheus-kafka-exporter
-version: 0.1.2
+version: 0.1.3
 home: https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
 sources:
   - https://github.com/danielqsj/kafka_exporter

--- a/charts/prometheus-kafka-exporter/templates/deployment.yaml
+++ b/charts/prometheus-kafka-exporter/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             - '--kafka.server={{ $server }}'
           {{- end }}
           {{- if .Values.tls.enabled }}
-            - '--tls.enabled=true'
+            - '--tls.enabled'
             - '--tls.ca-file={{ .Values.tls.mountPath }}/ca.crt'
             - '--tls.cert-file={{ .Values.tls.mountPath }}/tls.crt'
             - '--tls.key-file={{ .Values.tls.mountPath }}/tls.key'


### PR DESCRIPTION
Hi,
I'm sorry but I introduced a bug that prevents kafka-exporter to start due to a bad setting for tls.enabled. This PR fixes the bug.
Thank you