### PR TITLE
[prometheus-container-resource-exporter] service monitor port name fix

### DIFF
--- a/charts/prometheus-container-resource-exporter/templates/serviceMonitor.yaml
+++ b/charts/prometheus-container-resource-exporter/templates/serviceMonitor.yaml
@@ -16,7 +16,7 @@ spec:
   {{- toYaml . | nindent 6 }}
 {{- end }}
   endpoints:
-  - port: http
+  - port: server-port
     path: /metrics
     {{- with .Values.monitoring.serviceMonitor.metricsRelabelings }}
     metricRelabelings:


### PR DESCRIPTION
Fix the port name to match the service port name